### PR TITLE
Add tracking headers

### DIFF
--- a/langchain_aimlapi/__init__.py
+++ b/langchain_aimlapi/__init__.py
@@ -1,6 +1,7 @@
 from importlib import metadata
 
 from langchain_aimlapi.chat_models import ChatAimlapi
+from langchain_aimlapi.constants import AIMLAPI_HEADERS
 from langchain_aimlapi.document_loaders import AimlapiLoader
 from langchain_aimlapi.embeddings import AimlapiEmbeddings
 from langchain_aimlapi.imagegen import AimlapiImageGenerator
@@ -27,5 +28,6 @@ __all__ = [
     "AimlapiTool",
     "AimlapiImageGenerator",
     "AimlapiVideoGenerator",
+    "AIMLAPI_HEADERS",
     "__version__",
 ]

--- a/langchain_aimlapi/chat_models.py
+++ b/langchain_aimlapi/chat_models.py
@@ -16,6 +16,8 @@ from langchain_core.messages import (
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from pydantic import Field
 
+from langchain_aimlapi.constants import AIMLAPI_HEADERS
+
 
 class ChatAimlapi(BaseChatModel):
     """Wrapper for the OpenAI-compatible Aimlapi chat completion API.
@@ -66,6 +68,7 @@ class ChatAimlapi(BaseChatModel):
             base_url=self.base_url,
             timeout=self.timeout,
             max_retries=self.max_retries,
+            default_headers=AIMLAPI_HEADERS,
         )
 
     @staticmethod
@@ -83,11 +86,11 @@ class ChatAimlapi(BaseChatModel):
         return result
 
     def _generate(
-            self,
-            messages: List[BaseMessage],
-            stop: Optional[List[str]] = None,
-            run_manager: Optional[CallbackManagerForLLMRun] = None,
-            **kwargs: Any,
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
     ) -> ChatResult:
         client = self._client()
         if client is None:
@@ -130,11 +133,11 @@ class ChatAimlapi(BaseChatModel):
         return ChatResult(generations=[generation])
 
     def _stream(
-            self,
-            messages: List[BaseMessage],
-            stop: Optional[List[str]] = None,
-            run_manager: Optional[CallbackManagerForLLMRun] = None,
-            **kwargs: Any,
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
     ) -> Iterator[ChatGenerationChunk]:
         client = self._client()
         if client is None:

--- a/langchain_aimlapi/constants.py
+++ b/langchain_aimlapi/constants.py
@@ -1,0 +1,4 @@
+AIMLAPI_HEADERS = {
+    "HTTP-Referer": "https://github.com/langchain-ai/langchain",
+    "X-Title": "LangChain",
+}

--- a/langchain_aimlapi/embeddings.py
+++ b/langchain_aimlapi/embeddings.py
@@ -4,12 +4,20 @@ from typing import List, Optional
 import openai
 from langchain_core.embeddings import Embeddings
 
+from langchain_aimlapi.constants import AIMLAPI_HEADERS
+
 
 class AimlapiEmbeddings(Embeddings):
     """Embeddings powered by the Aimlapi OpenAI-compatible API."""
 
-    def __init__(self, model: str, api_key: Optional[str] = None, base_url: str = "https://api.aimlapi.com/v1",
-                 timeout: Optional[float] = None, max_retries: int = 2):
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.aimlapi.com/v1",
+        timeout: Optional[float] = None,
+        max_retries: int = 2,
+    ):
         self.model = model
         self.api_key = api_key
         self.base_url = base_url
@@ -25,6 +33,7 @@ class AimlapiEmbeddings(Embeddings):
             base_url=self.base_url,
             timeout=self.timeout,
             max_retries=self.max_retries,
+            default_headers=AIMLAPI_HEADERS,
         )
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:

--- a/langchain_aimlapi/imagegen.py
+++ b/langchain_aimlapi/imagegen.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 import openai
 from pydantic import Field
 
+from langchain_aimlapi.constants import AIMLAPI_HEADERS
+
 
 class AimlapiImageGenerator:
     """Generate images using the Aimlapi service."""
@@ -16,9 +18,14 @@ class AimlapiImageGenerator:
     timeout: Optional[float] = None
     max_retries: int = 2
 
-    def __init__(self, model: str = "dall-e-3", api_key: Optional[str] = None,
-                 base_url: str = "https://api.aimlapi.com/v1", timeout: Optional[float] = None,
-                 max_retries: int = 2) -> None:
+    def __init__(
+        self,
+        model: str = "dall-e-3",
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.aimlapi.com/v1",
+        timeout: Optional[float] = None,
+        max_retries: int = 2,
+    ) -> None:
         self.model = model
         self.api_key = api_key
         self.base_url = base_url
@@ -31,9 +38,16 @@ class AimlapiImageGenerator:
             base_url=self.base_url,
             timeout=self.timeout,
             max_retries=self.max_retries,
+            default_headers=AIMLAPI_HEADERS,
         )
 
-    def generate(self, prompt: str, n: int = 1, size: str = "1024x1024", response_format: str = "url") -> List[str]:
+    def generate(
+        self,
+        prompt: str,
+        n: int = 1,
+        size: str = "1024x1024",
+        response_format: str = "url",
+    ) -> List[str]:
         client = self._client()
         resp = client.images.generate(
             model=self.model,

--- a/langchain_aimlapi/videogen.py
+++ b/langchain_aimlapi/videogen.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 import httpx
 from pydantic import Field
 
+from langchain_aimlapi.constants import AIMLAPI_HEADERS
+
 
 class AimlapiVideoGenerator:
     """Generate videos using the Aimlapi service."""
@@ -16,9 +18,14 @@ class AimlapiVideoGenerator:
     timeout: Optional[float] = None
     max_retries: int = 2
 
-    def __init__(self, model: str = "google/veo3", api_key: Optional[str] = None,
-                 base_url: str = "https://api.aimlapi.com/v1", timeout: Optional[float] = None,
-                 max_retries: int = 2) -> None:
+    def __init__(
+        self,
+        model: str = "google/veo3",
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.aimlapi.com/v1",
+        timeout: Optional[float] = None,
+        max_retries: int = 2,
+    ) -> None:
         self.model = model
         self.api_key = api_key
         self.base_url = base_url
@@ -28,10 +35,20 @@ class AimlapiVideoGenerator:
     def _client(self) -> httpx.Client:
         return httpx.Client(timeout=self.timeout)
 
-    def generate(self, prompt: str, n: int = 1, response_format: str = "url") -> List[str]:
+    def generate(
+        self, prompt: str, n: int = 1, response_format: str = "url"
+    ) -> List[str]:
         client = self._client()
-        headers = {"Authorization": f"Bearer {self.api_key or os.getenv('AIMLAPI_API_KEY')}"}
-        payload = {"model": self.model, "prompt": prompt, "n": n, "response_format": response_format}
+        headers = {
+            **AIMLAPI_HEADERS,
+            "Authorization": f"Bearer {self.api_key or os.getenv('AIMLAPI_API_KEY')}",
+        }
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "n": n,
+            "response_format": response_format,
+        }
         url = f"{self.base_url}/videos/generations"
         for _ in range(self.max_retries + 1):
             resp = client.post(url, json=payload, headers=headers)


### PR DESCRIPTION
## Summary
- expose AIMLAPI_HEADERS constant
- attach default headers to HTTP clients in `ChatAimlapi`, `AimlapiEmbeddings`, `AimlapiImageGenerator`, and `AimlapiVideoGenerator`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865322f34d08329b6282c654f1bee5d