### PR TITLE
Improve chat model implementation

### DIFF
--- a/langchain_aimlapi/chat_models.py
+++ b/langchain_aimlapi/chat_models.py
@@ -1,14 +1,14 @@
 """Aimlapi chat models."""
 
+import json
 import logging
 import os
 import time
-import json
 from typing import Any, Dict, Iterator, List, Optional, Type
 
 import openai
-from openai import OpenAIError
 from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models import BaseChatModel
@@ -17,11 +17,18 @@ from langchain_core.messages import (
     AIMessageChunk,
     BaseMessage,
 )
-from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.messages.ai import UsageMetadata, subtract_usage
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
+from langchain_core.outputs import (
+    ChatGeneration,
+    ChatGenerationChunk,
+    ChatResult,
+    Generation,
+    LLMResult,
+)
 from langchain_core.runnables import Runnable, RunnableLambda, RunnableMap
 from langchain_core.utils.function_calling import convert_to_json_schema
-from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
+from openai import OpenAIError
 from pydantic import BaseModel, Field
 
 from langchain_aimlapi.constants import AIMLAPI_HEADERS
@@ -52,6 +59,7 @@ class ChatAimlapi(BaseChatModel):
 
     def _execute_with_retry(self, fn, *args, **kwargs):
         """Run ``fn`` with retries and exponential backoff on API errors."""
+        # retry with exponential backoff on API errors
         last_err = None
         for attempt in range(self.max_retries + 1):
             try:
@@ -168,6 +176,11 @@ class ChatAimlapi(BaseChatModel):
             )
             return ChatResult(generations=[ChatGeneration(message=message)])
 
+        filtered_kwargs = {
+            k: v
+            for k, v in self.model_kwargs.items()
+            if k not in {"model", "temperature", "max_tokens", "stop"}
+        }
         response = self._execute_with_retry(
             client.chat.completions.create,
             model=self.model_name,
@@ -175,7 +188,7 @@ class ChatAimlapi(BaseChatModel):
             temperature=self.temperature,
             max_tokens=self.max_tokens,
             stop=stop,
-            **self.model_kwargs,
+            **filtered_kwargs,
             **kwargs,
         )
 
@@ -212,6 +225,7 @@ class ChatAimlapi(BaseChatModel):
                 usage = None
                 resp_meta = None
                 if i == 0:
+                    # first chunk: initialize usage & finish_reason
                     usage = {
                         "input_tokens": input_tokens,
                         "output_tokens": 1,
@@ -229,6 +243,11 @@ class ChatAimlapi(BaseChatModel):
                 yield gen_chunk
             return
 
+        filtered_kwargs = {
+            k: v
+            for k, v in self.model_kwargs.items()
+            if k not in {"model", "temperature", "max_tokens", "stop"}
+        }
         stream = self._execute_with_retry(
             client.chat.completions.create,
             model=self.model_name,
@@ -237,7 +256,7 @@ class ChatAimlapi(BaseChatModel):
             max_tokens=self.max_tokens,
             stop=stop,
             stream=True,
-            **self.model_kwargs,
+            **filtered_kwargs,
             **kwargs,
         )
         prev_usage = None
@@ -250,8 +269,10 @@ class ChatAimlapi(BaseChatModel):
                     output_tokens=chunk.usage.completion_tokens,
                     total_tokens=chunk.usage.total_tokens,
                 )
-                # compute usage difference since last chunk
-                usage_delta = subtract_usage(current, prev_usage) if prev_usage else current
+                # compute delta-usage since prev_usage
+                usage_delta = (
+                    subtract_usage(current, prev_usage) if prev_usage else current
+                )
                 prev_usage = current
             resp_meta = {
                 "model_name": self.model_name,
@@ -265,3 +286,27 @@ class ChatAimlapi(BaseChatModel):
             if run_manager:
                 run_manager.on_llm_new_token(token, chunk=gen_chunk)
             yield gen_chunk
+
+    def _call(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> LLMResult:
+        result = self._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        gen = result.generations[0]
+        return LLMResult(generations=[[Generation(message=gen.message)]])
+
+    async def _acall(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> LLMResult:
+        result = await self._agenerate(
+            messages, stop=stop, run_manager=run_manager, **kwargs
+        )
+        gen = result.generations[0]
+        return LLMResult(generations=[[Generation(message=gen.message)]])

--- a/tests/unit_tests/test_chat_models_extra.py
+++ b/tests/unit_tests/test_chat_models_extra.py
@@ -1,0 +1,81 @@
+import types
+from unittest import mock
+
+from langchain_core.messages import HumanMessage
+from openai import OpenAIError
+from pydantic import BaseModel
+
+from langchain_aimlapi.chat_models import ChatAimlapi
+
+
+class SampleSchema(BaseModel):
+    foo: str
+
+
+def test_with_structured_output_local():
+    model = ChatAimlapi(model="bird-brain-001")
+    runnable = model.with_structured_output(SampleSchema)
+    result = runnable.invoke("hi")
+    assert isinstance(result, SampleSchema)
+
+
+def test_execute_with_retry():
+    model = ChatAimlapi(model="bird-brain-001", max_retries=1)
+    calls = []
+
+    def fn():
+        if not calls:
+            calls.append(1)
+            raise OpenAIError("boom")
+        return "ok"
+
+    with mock.patch("time.sleep", return_value=None):
+        assert model._execute_with_retry(fn) == "ok"
+    assert calls == [1]
+
+
+def test_stream_usage_deltas():
+    model = ChatAimlapi(model="bird-brain-001")
+
+    class Usage:
+        def __init__(self, p, c, t):
+            self.prompt_tokens = p
+            self.completion_tokens = c
+            self.total_tokens = t
+
+    class FakeChunk:
+        def __init__(self, token, usage, finish_reason=None):
+            self.choices = [
+                types.SimpleNamespace(
+                    delta=types.SimpleNamespace(content=token),
+                    finish_reason=finish_reason,
+                )
+            ]
+            self.usage = usage
+
+    stream = iter(
+        [
+            FakeChunk("h", Usage(1, 1, 2), "stop"),
+            FakeChunk("i", Usage(1, 2, 3), None),
+        ]
+    )
+
+    class FakeClient:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=lambda **_: stream)
+            )
+
+    with mock.patch.object(model, "_client", return_value=FakeClient()):
+        chunks = list(model._stream([HumanMessage(content="hi")]))
+
+    assert chunks[0].message.usage_metadata == {
+        "input_tokens": 1,
+        "output_tokens": 1,
+        "total_tokens": 2,
+    }
+    assert chunks[1].message.usage_metadata == {
+        "input_tokens": 0,
+        "output_tokens": 1,
+        "total_tokens": 1,
+    }


### PR DESCRIPTION
## Summary
- handle structured output with explicit response format
- improve streaming usage tracking and add `_call`/`_acall` helpers
- filter conflicting kwargs in chat client
- add unit tests for retry logic, structured output and streaming usage
- revert changes to llms module

## Testing
- `pytest tests/unit_tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68683285f1408329b5e8814aca162182