### PR TITLE
Improve Aimlapi retry logic and add unit tests

### DIFF
--- a/tests/unit_tests/test_chat_models_extra.py
+++ b/tests/unit_tests/test_chat_models_extra.py
@@ -1,0 +1,91 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage
+from openai import OpenAIError
+from pydantic import BaseModel
+
+from langchain_aimlapi.chat_models import ChatAimlapi
+
+
+class DummyError(OpenAIError):
+    pass
+
+
+class Person(BaseModel):
+    name: str
+    age: str
+
+
+def test_retry_backoff(monkeypatch):
+    chat = ChatAimlapi(model="bird-brain-001", api_key="sk")
+    count = 0
+
+    def fail(*args: Any, **kwargs: Any):
+        nonlocal count
+        count += 1
+        if count < 3:
+            raise DummyError("fail")
+
+        class Resp:
+            choices = [MagicMock(message=MagicMock(content="hi", finish_reason="stop"))]
+            usage = MagicMock(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+
+        return Resp()
+
+    sleeps = []
+    monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
+    result = chat._execute_with_retry_sync(fail)
+    assert result.choices[0].message.content == "hi"
+    assert sleeps == [1, 2]
+
+
+def test_parrot_fallback():
+    chat = ChatAimlapi(model="bird-brain-001", parrot_buffer_length=4)
+    res = chat._generate([HumanMessage(content="abcdef")])
+    assert res.generations[0].message.content == "abcd"
+
+
+def test_filtering_stop(monkeypatch):
+    recorded = {}
+
+    class Client:
+        class Chat:
+            class Completions:
+                def create(self, **kwargs: Any):
+                    recorded.update(kwargs)
+
+                    class Resp:
+                        choices = [
+                            MagicMock(
+                                message=MagicMock(content="hi", finish_reason="stop")
+                            )
+                        ]
+                        usage = MagicMock(
+                            prompt_tokens=0, completion_tokens=0, total_tokens=0
+                        )
+
+                    return Resp()
+
+            completions = Completions()
+
+        chat = Chat()
+
+    chat_model = ChatAimlapi(
+        model="bird-brain-001",
+        api_key="sk",
+        model_kwargs={"stop": ["bad"], "temperature": 2, "foo": "bar"},
+    )
+    monkeypatch.setattr(chat_model, "_client", lambda: Client())
+    chat_model._generate([HumanMessage(content="hi")], stop="THE END")
+    assert recorded["stop"] == ["THE END"]
+    assert recorded.get("foo") == "bar"
+    assert recorded.get("model") == "bird-brain-001"
+
+
+def test_structured_output():
+    chat = ChatAimlapi(model="bird-brain-001")
+    runnable = chat.with_structured_output(Person)
+    result = runnable.invoke("tell me")
+    assert isinstance(result, Person)

--- a/tests/unit_tests/test_llms.py
+++ b/tests/unit_tests/test_llms.py
@@ -1,0 +1,70 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from openai import OpenAIError
+
+from langchain_aimlapi.llms import AimlapiLLM
+
+
+class DummyError(OpenAIError):
+    pass
+
+
+def test_retry_backoff(monkeypatch):
+    llm = AimlapiLLM(model="bird-brain-001", api_key="sk")
+    call_times = []
+
+    def fail_first(*args: Any, **kwargs: Any):
+        call_times.append("call")
+        if len(call_times) < 3:
+            raise DummyError("fail")
+        return "ok"
+
+    sleeps = []
+    monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
+
+    result = llm._execute_with_retry_sync(fail_first)
+    assert result == "ok"
+    assert sleeps == [1, 2]
+
+
+def test_fallback_no_key():
+    llm = AimlapiLLM(model="bird-brain-001", parrot_buffer_length=5)
+    result = llm._call("hello world")
+    assert result.generations[0][0].text == "hello"  # parroted output
+
+
+def test_kwargs_filtering_and_stop(monkeypatch):
+    recorded = {}
+
+    class Client:
+        class Completions:
+            def create(self, **kwargs: Any):
+                recorded.update(kwargs)
+
+                class Resp:
+                    choices = [MagicMock(text="hi", finish_reason="stop")]
+                    usage = MagicMock(
+                        prompt_tokens=0, completion_tokens=0, total_tokens=0
+                    )
+
+                return Resp()
+
+        completions = Completions()
+
+    llm = AimlapiLLM(
+        model="bird-brain-001",
+        api_key="sk",
+        model_kwargs={"model": "bad", "temperature": 2, "foo": 1},
+    )
+    monkeypatch.setattr(llm, "_client", lambda: Client())
+    result = llm._call("test", stop="END")
+    assert recorded["stop"] == ["END"]
+    assert (
+        "foo" in recorded
+        and "model" in recorded
+        and recorded["model"] == "bird-brain-001"
+    )
+    assert recorded.get("temperature") == llm.temperature
+    assert result.generations[0][0].text == "hi"


### PR DESCRIPTION
## Summary
- add explicit sync/async retry helpers with capped backoff
- normalize stop params and filter `model_kwargs`
- update documentation and inline comments
- implement Generation usage for LLM fallback
- test retry/backoff, fallback, kwargs filtering, and structured output

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_686863d5d15883299022e4057fd53aff